### PR TITLE
Add support for React 0.13.x

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
   </style>
 </head>
 <body>
-<script src="//fb.me/react-with-addons-0.12.1.js"></script>
-<script src="//fb.me/JSXTransformer-0.12.1.js"></script>
+<script src="https://fb.me/react-with-addons-0.13.2.js"></script>
+<script src="https://fb.me/JSXTransformer-0.13.2.js"></script>
 <script src="dist/react-loading.js"></script>
 <script type="text/jsx">
   var App = React.createClass({

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cezary/react-loading",
   "peerDependencies": {
-    "react": "^0.12.1"
+    "react": ">=0.12.0 <0.14.0"
   },
   "devDependencies": {
     "jsx-loader": "^0.12.2",


### PR DESCRIPTION
Fix #3 
Everything seems to work fine when running the component in React 0.13.2.